### PR TITLE
feat: deduplicate parallel requests with same root and selector

### DIFF
--- a/packages/myel-client/src/__tests__/Client.spec.ts
+++ b/packages/myel-client/src/__tests__/Client.spec.ts
@@ -55,6 +55,8 @@ describe('MyelClient', () => {
 
     const state = await Promise.all([
       client.loadAsync(offer, allSelector),
+      // test deduplication
+      client.loadAsync(offer, allSelector),
       // here the order is crucial
       client
         ._handleGraphsyncMsg(ppid, fix.gsMsg1)
@@ -65,6 +67,8 @@ describe('MyelClient', () => {
     expect(state[0].matches('completed')).toBe(true);
     expect(state[0].context.received).toBe(1214);
     expect(state[0].context.allReceived).toBe(true);
+
+    expect(state[1].matches('completed')).toBe(true);
   });
 
   test('handles a one block transfer', async () => {

--- a/packages/myel-client/src/selectors.ts
+++ b/packages/myel-client/src/selectors.ts
@@ -1,7 +1,8 @@
 import {CID} from 'multiformats';
 import {decode as decodePb} from '@ipld/dag-pb';
-import {decode as decodeCbor} from '@ipld/dag-cbor';
+import {decode as decodeCbor, encode as encodeCbor} from '@ipld/dag-cbor';
 import {Blockstore} from 'interface-blockstore';
+import {equals} from './filaddress';
 
 enum Kind {
   Invalid = '',
@@ -68,6 +69,10 @@ function is(value: any): Kind {
     return Kind.Link;
   }
   return Kind.Invalid;
+}
+
+export function selEquals(a: SelectorNode, b: SelectorNode): boolean {
+  return equals(encodeCbor(a), encodeCbor(b));
 }
 
 class Node {


### PR DESCRIPTION
Fixes some flakiness during parallel transfers with the same root